### PR TITLE
Devnet RPC URL error

### DIFF
--- a/docs/expchain/002-rpc.md
+++ b/docs/expchain/002-rpc.md
@@ -15,7 +15,7 @@ Visit the [ChainList](https://chainlist.org/chain/18880) and connect to your wal
 - https://rpc1-testnet.expchain.ai
 
 ## EXPchain Devnet(ChainID 0x70D0, 28880 in decimal)
-- https://rpc-devnet.expachain.ai
+- https://rpc-devnet.expchain.ai
 
 ## Starting HTTP JSON-RPC
 

--- a/docs/expchain/003-wallet.md
+++ b/docs/expchain/003-wallet.md
@@ -27,7 +27,7 @@ sidebar_position: 4
 
 - Network Name: EXPchain Devnet
 - RPC URL:
-  - [https://rpc-devnet.expachain.ai](https://rpc-devnet.expachain.ai)
+  - [https://rpc-devnet.expchain.ai](https://rpc-devnet.expchain.ai)
 - ChainID: 28880
 - Symbol: tZKJ
 - Explorer: [https://blockscout-devnet.expchain.ai/](https://blockscout-devnet.expchain.ai/)


### PR DESCRIPTION
RPC URL has the domain currently as `expachain.ai` instead of `expchain.ai`.